### PR TITLE
Format code and reinforce fmt guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 ## Build, Test, and Development Commands
 - `cargo build`: build the project in debug mode.
 - `cargo test`: run unit/integration tests (Rust’s built-in test harness).
-- `cargo fmt --check`: verify formatting matches `rustfmt`.
+- `cargo fmt --check`: verify formatting matches `rustfmt`. Run `cargo fmt` locally before committing so CI formatting checks always pass.
 - `cargo clippy -- -D warnings`: lint and treat warnings as errors.
 
 ## Coding Style & Naming Conventions

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -90,7 +90,10 @@ pub struct ImportItem {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AssignTarget {
-    Name { name: String, span: SourceSpan },
+    Name {
+        name: String,
+        span: SourceSpan,
+    },
     Attribute {
         value: Box<Expr>,
         attr: String,
@@ -105,11 +108,25 @@ pub enum AssignTarget {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
-    Name { name: String, span: SourceSpan },
-    Number { value: String, span: SourceSpan },
-    String { value: String, span: SourceSpan },
-    Bool { value: bool, span: SourceSpan },
-    None { span: SourceSpan },
+    Name {
+        name: String,
+        span: SourceSpan,
+    },
+    Number {
+        value: String,
+        span: SourceSpan,
+    },
+    String {
+        value: String,
+        span: SourceSpan,
+    },
+    Bool {
+        value: bool,
+        span: SourceSpan,
+    },
+    None {
+        span: SourceSpan,
+    },
     Unary {
         op: UnaryOp,
         expr: Box<Expr>,


### PR DESCRIPTION
## Summary
- document running `cargo fmt` locally to keep CI formatting checks passing
- apply `rustfmt` formatting updates across AST definitions and parser helpers

## Testing
- cargo fmt --check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954da66b9d48325a92601ef4ee43db8)