### PR TITLE
Fix clippy warning in not expression handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - `cargo build`: build the project in debug mode.
 - `cargo test`: run unit/integration tests (Rust’s built-in test harness).
 - `cargo fmt --check`: verify formatting matches `rustfmt`. Run `cargo fmt` locally before committing so CI formatting checks always pass.
-- `cargo clippy -- -D warnings`: lint and treat warnings as errors.
+- `cargo clippy -- -D warnings`: lint and treat warnings as errors. CI runs this command, so ensure it passes locally before committing.
 
 ## Coding Style & Naming Conventions
 - Use `rustfmt` defaults; 4-space indentation from formatter output.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -404,24 +404,25 @@ fn fold_left_binary(pair: Pair<'_, Rule>, source: &str, op: BinaryOp) -> Result<
 fn parse_not_expr(pair: Pair<'_, Rule>, source: &str) -> Result<Expr, ParseError> {
     let pair_span = span_from_pair(&pair, source);
     let mut inner = pair.into_inner().peekable();
-    if let Some(next) = inner.peek() {
-        if next.as_rule() == Rule::not_op {
-            let op_pair = inner.next().unwrap();
-            let operand_pair = inner.next().ok_or_else(|| {
-                error_with_span(
-                    "missing operand for not",
-                    span_from_pair(&op_pair, source),
-                    source,
-                )
-            })?;
-            let expr = parse_expr_pair(operand_pair, source)?;
-            let span = merge_span(&span_from_pair(&op_pair, source), expr_span(&expr));
-            return Ok(Expr::Unary {
-                op: UnaryOp::Not,
-                expr: Box::new(expr),
-                span,
-            });
-        }
+    if inner
+        .peek()
+        .is_some_and(|next| next.as_rule() == Rule::not_op)
+    {
+        let op_pair = inner.next().unwrap();
+        let operand_pair = inner.next().ok_or_else(|| {
+            error_with_span(
+                "missing operand for not",
+                span_from_pair(&op_pair, source),
+                source,
+            )
+        })?;
+        let expr = parse_expr_pair(operand_pair, source)?;
+        let span = merge_span(&span_from_pair(&op_pair, source), expr_span(&expr));
+        return Ok(Expr::Unary {
+            op: UnaryOp::Not,
+            expr: Box::new(expr),
+            span,
+        });
     }
     parse_expr_pair(
         inner


### PR DESCRIPTION
## Summary
- collapse the not-expression parsing check to satisfy clippy
- document that cargo clippy -- -D warnings runs in CI in AGENTS.md

## Testing
- cargo clippy -- -D warnings
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954db783f508325a5b4dcce29c287a7)