### PR TITLE
Update CI for Python integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,13 @@ on:
 jobs:
   rust:
     runs-on: ubuntu-latest
+    env:
+      PYO3_PYTHON: python3
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +59,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,16 +85,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pest"
@@ -112,12 +220,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -128,6 +305,46 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sha2"
@@ -141,11 +358,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "snail"
 version = "0.1.0"
 dependencies = [
  "pest",
  "pest_derive",
+ "pyo3",
+ "tempfile",
 ]
 
 [[package]]
@@ -157,6 +382,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -178,7 +422,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unindent"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@ name = "snail"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 pest = "2.7"
 pest_derive = "2.7"
+pyo3 = { version = "0.21", features = ["auto-initialize"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Python interpreter. The implementation language is still open and should be
 chosen based on parser ergonomics, ease of AST manipulation, and maintenance
 cost.
 
+Development notes
+
+- Python integration tests expect a usable CPython on `PATH`. Set `PYO3_PYTHON=
+  python3` (as CI does) if multiple Python versions are installed.
+
 Project plan
 
 Phase 0: Project scaffold and decisions
@@ -36,10 +41,10 @@ Phase 2: Lowering to Python AST
 - [x] Defer new syntax features until core pipeline is working.
 
 Phase 3: CPython integration
-- [ ] Implement a Python extension module (Rust + pyo3).
-- [ ] Provide a module API for compiling and executing Snail code.
-- [ ] Add a Python import hook so `import foo.snail` works.
-- [ ] Ensure Snail code can import Python modules directly.
+- [x] Implement a Python extension module (Rust + pyo3).
+- [x] Provide a module API for compiling and executing Snail code.
+- [x] Add a Python import hook so `import foo.snail` works.
+- [x] Ensure Snail code can import Python modules directly.
 
 Phase 4: Interop and runtime features
 - [ ] Ensure Snail functions/classes are normal Python callables.

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::fmt;
 
 use crate::ast::SourceSpan;
+use crate::lower::LowerError;
 
 #[derive(Debug, Clone)]
 pub struct ParseError {
@@ -39,3 +40,39 @@ impl fmt::Display for ParseError {
 }
 
 impl Error for ParseError {}
+
+#[derive(Debug)]
+pub enum SnailError {
+    Parse(ParseError),
+    Lower(LowerError),
+}
+
+impl fmt::Display for SnailError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SnailError::Parse(err) => write!(f, "{err}"),
+            SnailError::Lower(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl Error for SnailError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            SnailError::Parse(err) => Some(err),
+            SnailError::Lower(err) => Some(err),
+        }
+    }
+}
+
+impl From<ParseError> for SnailError {
+    fn from(value: ParseError) -> Self {
+        SnailError::Parse(value)
+    }
+}
+
+impl From<LowerError> for SnailError {
+    fn from(value: LowerError) -> Self {
+        SnailError::Lower(value)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,10 @@ mod ast;
 mod error;
 mod lower;
 mod parser;
+mod python;
 
 pub use crate::ast::*;
 pub use crate::error::*;
 pub use crate::lower::*;
 pub use crate::parser::*;
+pub use crate::python::*;

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,0 +1,124 @@
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use pyo3::exceptions::{PyException, PySyntaxError};
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyModule};
+
+use crate::{SnailError, lower_program, parse_program, python_source};
+
+pub fn compile_snail_source(source: &str) -> Result<String, SnailError> {
+    let program = parse_program(source)?;
+    let module = lower_program(&program)?;
+    Ok(python_source(&module))
+}
+
+fn compile_to_code(py: Python<'_>, source: &str, filename: &str) -> PyResult<PyObject> {
+    let python = compile_snail_source(source).map_err(to_py_err)?;
+    let builtins = PyModule::import_bound(py, "builtins")?;
+    let compiled = builtins
+        .getattr("compile")?
+        .call1((python, filename, "exec"))?;
+    Ok(compiled.into())
+}
+
+fn to_py_err(err: SnailError) -> PyErr {
+    match err {
+        SnailError::Parse(err) => PyErr::new::<PySyntaxError, _>(err.to_string()),
+        SnailError::Lower(err) => PyErr::new::<PyException, _>(err.to_string()),
+    }
+}
+
+#[pyfunction]
+#[allow(unsafe_op_in_unsafe_fn)]
+pub fn compile_snail(py: Python<'_>, source: &str, filename: Option<&str>) -> PyResult<PyObject> {
+    let filename = filename.unwrap_or("<snail>");
+    compile_to_code(py, source, filename)
+}
+
+#[pyfunction]
+#[allow(unsafe_op_in_unsafe_fn)]
+pub fn exec_snail(py: Python<'_>, source: &str, filename: Option<&str>) -> PyResult<PyObject> {
+    let filename = filename.unwrap_or("<snail>");
+    let code = compile_to_code(py, source, filename)?;
+    let globals = PyDict::new_bound(py);
+    PyModule::import_bound(py, "builtins")?
+        .getattr("exec")?
+        .call1((code, &globals, &globals))?;
+    Ok(globals.into())
+}
+
+#[pyfunction]
+#[allow(unsafe_op_in_unsafe_fn)]
+pub fn translate_snail(source: &str) -> PyResult<String> {
+    compile_snail_source(source).map_err(to_py_err)
+}
+
+#[pyfunction]
+pub fn install_import_hook(py: Python<'_>) -> PyResult<()> {
+    const IMPORTER_SOURCE: &str = r#"
+import importlib.abc
+import importlib.util
+import pathlib
+import sys
+
+from snail import compile_snail
+
+
+class SnailLoader(importlib.abc.SourceLoader):
+    def __init__(self, path):
+        self.path = pathlib.Path(path)
+
+    def get_filename(self, fullname):
+        return str(self.path)
+
+    def get_data(self, path):
+        return self.path.read_bytes()
+
+    def source_to_code(self, data, path, _opt=None):
+        source = data.decode('utf-8')
+        return compile_snail(source, str(self.path))
+
+
+class SnailFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        module_name = fullname.rsplit('.', 1)[-1]
+        search = path or sys.path
+        candidate = module_name + '.snail'
+        for entry in search:
+            potential = pathlib.Path(entry) / candidate
+            if potential.is_file():
+                loader = SnailLoader(potential)
+                return importlib.util.spec_from_file_location(fullname, potential, loader=loader)
+        return None
+
+
+def install():
+    for finder in sys.meta_path:
+        if isinstance(finder, SnailFinder):
+            return
+    sys.meta_path.insert(0, SnailFinder())
+"#;
+
+    let importer =
+        PyModule::from_code_bound(py, IMPORTER_SOURCE, "snail_importer.py", "snail_importer")?;
+    importer.getattr("install")?.call0()?;
+    Ok(())
+}
+
+#[pymodule]
+pub fn snail(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(compile_snail, m)?)?;
+    m.add_function(wrap_pyfunction!(exec_snail, m)?)?;
+    m.add_function(wrap_pyfunction!(translate_snail, m)?)?;
+    m.add_function(wrap_pyfunction!(install_import_hook, m)?)?;
+    Ok(())
+}
+
+pub fn register_in_python(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
+    let module = PyModule::new_bound(py, "snail")?;
+    snail(py, &module)?;
+
+    let sys = PyModule::import_bound(py, "sys")?;
+    sys.getattr("modules")?.set_item("snail", &module)?;
+    Ok(module)
+}

--- a/tests/python_integration.rs
+++ b/tests/python_integration.rs
@@ -1,0 +1,78 @@
+use std::fs;
+use std::path::PathBuf;
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use tempfile::TempDir;
+
+use snail::register_in_python;
+
+#[test]
+fn executes_snail_code_via_python_api() {
+    pyo3::prepare_freethreaded_python();
+    Python::with_gil(|py| {
+        let module = register_in_python(py).expect("snail module should register");
+        let locals = PyDict::new_bound(py);
+        locals.set_item("snail_module", &module).unwrap();
+
+        py.run_bound(
+            "import sys\nsys.modules['snail'] = snail_module\nfrom snail import exec_snail\nns = exec_snail('import math\\nresult = math.sqrt(16)')\nvalue = ns['result']",
+            None,
+            Some(&locals),
+        )
+        .expect("python should run snail code");
+
+        let value_obj = locals
+            .get_item("value")
+            .expect("value lookup should succeed")
+            .expect("value should be present");
+        let value: f64 = value_obj.extract::<f64>().unwrap();
+        assert_eq!(value, 4.0);
+    });
+}
+
+#[test]
+fn import_hook_loads_snail_files() {
+    pyo3::prepare_freethreaded_python();
+    let temp = TempDir::new().expect("temp dir");
+    let mut module_path = PathBuf::from(temp.path());
+    module_path.push("example.snail");
+    fs::write(
+        &module_path,
+        "import math\ndef compute() { return math.sqrt(9) }\nresult = compute()",
+    )
+    .expect("write snail file");
+
+    Python::with_gil(|py| {
+        let module = register_in_python(py).expect("snail module should register");
+        let locals = PyDict::new_bound(py);
+        locals.set_item("snail_module", &module).unwrap();
+        locals
+            .set_item("module_dir", temp.path().to_string_lossy().to_string())
+            .unwrap();
+
+        py.run_bound(
+            r#"
+import sys
+import importlib
+
+sys.modules['snail'] = snail_module
+from snail import install_import_hook
+install_import_hook()
+sys.path.insert(0, module_dir)
+import example
+value = example.result
+"#,
+            None,
+            Some(&locals),
+        )
+        .expect("python should import snail module");
+
+        let value_obj = locals
+            .get_item("value")
+            .expect("value lookup should succeed")
+            .expect("value should be present");
+        let value: f64 = value_obj.extract::<f64>().unwrap();
+        assert_eq!(value, 3.0);
+    });
+}


### PR DESCRIPTION
## Summary
- configure CI to install Python 3.12 and set `PYO3_PYTHON` for PyO3-based integration tests
- mark CPython integration tasks as complete and add development notes for the Python-backed tests

## Testing
- cargo fmt
- PYO3_PYTHON=python3 cargo test
- PYO3_PYTHON=python3 cargo clippy -- -D warnings

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955516808b48325b73f504517c28a91)