### PR TITLE
Treat regex literals as raw strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Phase 7: Snail Specific semantics
   code. In the case of the `$()` form, the __fallback__ method re-raises the
   exception forcing users to provide a fallback value.
   Both expand into expressions (not statements); complex cases should use Python's `subprocess` directly.
-- [ ] add a regex expression. `string in /<pattern>/` performes an re.search and returns any match object. 
+- [x] add a regex expression. `string in /<pattern>/` performes an re.search and returns any match object.
 
 Phase 8: Documentation and utilities
 - [x] Expand documentation, examples, and language reference.
@@ -127,7 +127,7 @@ Phase 9: Awk-style line processing
 - [x] Add an awk mode that evaluates pattern/action pairs across input lines.
 - [x] Provide syntactic sugar for common awk idioms (e.g., default actions, begin/end hooks).
 - [x] Surface a clear entry point for enabling awk mode (CLI flag or file directive) and document usage.
-- [ ] add support for the regex expression as a pattern. if no string is provided `line` is implicit. just the pattern is valid. the match object should be made available to the action.
+- [x] add support for the regex expression as a pattern. if no string is provided `line` is implicit. just the pattern is valid. the match object should be made available to the action.
 
 Phase 0 decisions (executed)
 - Implementation language: Rust (2024 edition).

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -108,6 +108,20 @@ prefer_lambda = risky_fallback() ? "lambda"
 dunder_only = risky_fallback()?
 ```
 
+## Regex expressions
+Use regex literals for concise searches:
+
+- `string in /<pattern>/` runs `re.search` and returns the match object (or
+  `None`), so truthiness checks work naturally.
+- `/pattern/` alone produces a compiled regex object you can reuse.
+- Regex literals are treated as raw strings and do not interpolate `{}`
+  expressions, so backslashes stay intact.
+- Escape `/` inside the pattern as `\/`.
+
+In awk mode, regex patterns can stand alone. A bare `/pattern/` matches against
+`line` implicitly and binds the match object to `match` for use inside the
+action block.
+
 ## Subprocess expressions
 Snail provides succinct subprocess helpers:
 - `$(<command>)` runs the command, captures stdout, and returns it as a string.

--- a/examples/all_syntax.snail
+++ b/examples/all_syntax.snail
@@ -145,6 +145,10 @@ except ValueError as err {
 safe_value = risky()?
 safe_fallback = risky() ? $e
 safe_details = risky() ? $e.args[0]
+text = "abc123"
+regex_match = text in /abc(\d+)/
+compiled_regex = /abc(\d+)/
+compiled_match = compiled_regex.search(text)
 
 def fallback_handler() {
     return "dunder"
@@ -191,6 +195,7 @@ print("tail", tail)
 print("safe_value", safe_value)
 print("safe_fallback", safe_fallback)
 print("safe_details", safe_details)
+print("regex", regex_match.group(1), compiled_match.group(1))
 print("echoed", echoed)
 print("status_ok", status_ok)
 print("status_fail", status_fail)

--- a/examples/awk.snail
+++ b/examples/awk.snail
@@ -1,5 +1,6 @@
 #!snail awk
 BEGIN { print("demo begin") }
 line.startswith("d") { print("matched: {line}") }
+/demo/ { print("regex: {match.group(0)}") }
 { print(fnr) }
 END { print("demo end") }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -200,6 +200,15 @@ pub enum Expr {
         fallback: Option<Box<Expr>>,
         span: SourceSpan,
     },
+    Regex {
+        pattern: String,
+        span: SourceSpan,
+    },
+    RegexMatch {
+        value: Box<Expr>,
+        pattern: String,
+        span: SourceSpan,
+    },
     Subprocess {
         kind: SubprocessKind,
         parts: Vec<SubprocessPart>,

--- a/src/snail.pest
+++ b/src/snail.pest
@@ -105,6 +105,7 @@ slice_end = { expr }
 
 atom = _{
   literal
+  | regex
   | subprocess
   | exception_var
   | identifier
@@ -146,6 +147,7 @@ triple_double = { "\"\"\"" ~ (!"\"\"\"" ~ ANY)* ~ "\"\"\"" }
 triple_single = { "'''" ~ (!"'''" ~ ANY)* ~ "'''" }
 double_string = { "\"" ~ ( "\\\"" | !"\"" ~ ANY )* ~ "\"" }
 single_string = { "'" ~ ( "\\'" | !"'" ~ ANY )* ~ "'" }
+regex = @{ "/" ~ ( "\\/" | !"/" ~ ANY )* ~ "/" }
 
 identifier = @{ !keyword ~ ident_start ~ ident_continue* }
 ident_start = { ASCII_ALPHA | "_" }

--- a/tests/lower.rs
+++ b/tests/lower.rs
@@ -351,6 +351,27 @@ code = @(echo ok)
     assert_eq!(rendered, expected);
 }
 
+#[test]
+fn renders_regex_expressions() {
+    let source = r#"
+text = "value"
+found = text in /val(.)/
+compiled = /abc/
+"#;
+    let program = parse_program(source).expect("program should parse");
+    let module = lower_program(&program).expect("program should lower");
+    let rendered = python_source(&module);
+    let expected = "import re\n\n".to_string()
+        + "def __snail_regex_search(value, pattern):\n"
+        + "    return re.search(pattern, value)\n\n"
+        + "def __snail_regex_compile(pattern):\n"
+        + "    return re.compile(pattern)\n\n"
+        + "text = f\"value\"\n"
+        + "found = __snail_regex_search(text, r\"val(.)\")\n"
+        + "compiled = __snail_regex_compile(r\"abc\")\n";
+    assert_eq!(rendered, expected);
+}
+
 fn assert_name_location(expr: &snail::PyExpr, expected: &str, line: usize, column: usize) {
     match expr {
         snail::PyExpr::Name { id, span } => {

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -196,3 +196,14 @@ code = @(echo ok)
     let program = parse_program(source).expect("program should parse");
     assert_eq!(program.stmts.len(), 3);
 }
+
+#[test]
+fn parses_regex_expressions() {
+    let source = r#"
+text = "value"
+found = text in /val(.)/
+compiled = /abc/
+"#;
+    let program = parse_program(source).expect("program should parse");
+    assert_eq!(program.stmts.len(), 3);
+}


### PR DESCRIPTION
## Summary
- generate regex helper calls with raw string patterns to avoid interpolation and escape warnings
- simplify regex match detection in the parser per clippy guidance
- document raw regex literal behavior and update regex lowering expectations

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956b22057e08325a0582042e63c2323)