### PR TITLE
Guard injected awk variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Awk mode is available for line-oriented scripts. Enable it with `snail --awk`
 or by starting a file with `#!snail awk`. Awk sources are written as
 pattern/action pairs evaluated for each input line. `BEGIN` and `END` blocks run
 before and after the line loop, a lone pattern defaults to printing matching
-lines, and a bare block runs for every line. Built-in variables mirror awk: the
-current line as `line`, whitespace-split fields as `fields`, and counters `nr`
-and `fnr` for global and per-file line numbers.
+lines, and a bare block runs for every line. Built-in variables mirror awk but
+use short `$`-prefixed names: the current line as `$l`, whitespace-split fields
+as `$f`, counters `$n` and `$fn` for global and per-file line numbers, the
+current file path as `$p`, and `$m` for the last regex match. These `$` names
+are injected by Snail itself; user-defined identifiers cannot start with `$`.
 
 The compiler/transpiler will generate Python source and execute it with the
 Python interpreter. The implementation language is still open and should be
@@ -127,7 +129,7 @@ Phase 9: Awk-style line processing
 - [x] Add an awk mode that evaluates pattern/action pairs across input lines.
 - [x] Provide syntactic sugar for common awk idioms (e.g., default actions, begin/end hooks).
 - [x] Surface a clear entry point for enabling awk mode (CLI flag or file directive) and document usage.
-- [x] add support for the regex expression as a pattern. if no string is provided `line` is implicit. just the pattern is valid. the match object should be made available to the action.
+- [x] add support for the regex expression as a pattern. if no string is provided `$l` is implicit. just the pattern is valid. the match object should be made available to the action.
 
 Phase 0 decisions (executed)
 - Implementation language: Rust (2024 edition).

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -119,8 +119,8 @@ Use regex literals for concise searches:
 - Escape `/` inside the pattern as `\/`.
 
 In awk mode, regex patterns can stand alone. A bare `/pattern/` matches against
-`line` implicitly and binds the match object to `match` for use inside the
-action block.
+`$l` implicitly and binds the match object to `$m` for use inside the action
+block.
 
 ## Subprocess expressions
 Snail provides succinct subprocess helpers:
@@ -156,11 +156,15 @@ for every line.
 See `examples/awk.snail` for a runnable sample program.
 
 While processing, Snail populates awk-style variables:
-- `line`: the current line with the trailing newline removed.
-- `fields`: `line.split()` on whitespace.
-- `nr`: global line counter across all files.
-- `fnr`: per-file line counter.
-- `path`: the active filename, with `"-"` representing stdin.
+- `$l`: the current line with the trailing newline removed.
+- `$f`: `$l.split()` on whitespace.
+- `$n`: global line counter across all files.
+- `$fn`: per-file line counter.
+- `$p`: the active filename, with `"-"` representing stdin.
+- `$m`: the last regex match object.
+
+These `$` variables are injected by the language; user-defined identifiers
+cannot start with `$`.
 
 Input files come from `sys.argv[1:]`; when none are provided, awk mode reads
 stdin. Pass `--` to the CLI to forward filenames or other arguments into the

--- a/examples/awk.snail
+++ b/examples/awk.snail
@@ -1,6 +1,6 @@
 #!snail awk
 BEGIN { print("demo begin") }
-line.startswith("d") { print("matched: {line}") }
-/demo/ { print("regex: {match.group(0)}") }
-{ print(fnr) }
+$l.startswith("d") { print("matched:", $l) }
+/demo/ { print("regex:", $m.group(0)) }
+{ print($fn) }
 END { print("demo end") }

--- a/extras/vim/syntax/snail.vim
+++ b/extras/vim/syntax/snail.vim
@@ -29,7 +29,7 @@ syn keyword snailKeyword True try while with yield
 " Snail-specific syntax helpers
 syn match snailSubprocess "\$([^)]*)"
 syn match snailSubprocessBg "@([^)]*)"
-syn match snailFallbackVar "\$e"
+syn match snailInjectedVar "\$\(e\|l\|f\|n\|fn\|p\|m\)"
 syn match snailSwallow "?" containedin=snailOperator
 
 syn match snailOperator "[][{}():.,]"
@@ -42,7 +42,7 @@ hi def link snailFormat         Special
 hi def link snailKeyword        Keyword
 hi def link snailSubprocess     Function
 hi def link snailSubprocessBg   Function
-hi def link snailFallbackVar    Identifier
+hi def link snailInjectedVar    Identifier
 hi def link snailSwallow        Operator
 hi def link snailOperator       Operator
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -775,6 +775,10 @@ fn parse_expr_pair(pair: Pair<'_, Rule>, source: &str) -> Result<Expr, ParseErro
             name: pair.as_str().to_string(),
             span: span_from_pair(&pair, source),
         }),
+        Rule::injected_var => Ok(Expr::Name {
+            name: pair.as_str().to_string(),
+            span: span_from_pair(&pair, source),
+        }),
         Rule::identifier => Ok(Expr::Name {
             name: pair.as_str().to_string(),
             span: span_from_pair(&pair, source),
@@ -1251,6 +1255,10 @@ fn parse_atom(pair: Pair<'_, Rule>, source: &str) -> Result<Expr, ParseError> {
     match inner_pair.as_rule() {
         Rule::literal => parse_literal(inner_pair, source),
         Rule::exception_var => Ok(Expr::Name {
+            name: inner_pair.as_str().to_string(),
+            span: span_from_pair(&inner_pair, source),
+        }),
+        Rule::injected_var => Ok(Expr::Name {
             name: inner_pair.as_str().to_string(),
             span: span_from_pair(&inner_pair, source),
         }),

--- a/src/snail.pest
+++ b/src/snail.pest
@@ -4,7 +4,7 @@ awk_entry_list = { awk_entry ~ (stmt_sep+ ~ awk_entry)* ~ stmt_sep? }
 awk_entry = _{ awk_begin | awk_end | awk_rule }
 awk_begin = { "BEGIN" ~ block }
 awk_end = { "END" ~ block }
-awk_rule = { awk_pattern? ~ block? }
+awk_rule = { awk_pattern ~ block? | block }
 awk_pattern = { expr }
 
 stmt_list = { stmt ~ (stmt_sep ~ stmt)* ~ stmt_sep? }
@@ -108,6 +108,7 @@ atom = _{
   | regex
   | subprocess
   | exception_var
+  | injected_var
   | identifier
   | list_comp
   | list_literal
@@ -140,6 +141,7 @@ literal = { number | string | boolean | none }
 boolean = { "True" | "False" }
 none = { "None" }
 exception_var = { "$e" }
+injected_var = { "$fn" | "$l" | "$f" | "$n" | "$p" | "$m" }
 number = @{ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)? }
 string = @{ raw_prefix? ~ (triple_double | triple_single | double_string | single_string) }
 raw_prefix = { "r" }

--- a/tests/awk.rs
+++ b/tests/awk.rs
@@ -5,7 +5,7 @@ use std::process::{Command, Stdio};
 fn awk_flag_filters_input() {
     let exe = env!("CARGO_BIN_EXE_snail");
     let mut child = Command::new(exe)
-        .args(["--awk", "-c", "line.startswith('a') { print(line) }"])
+        .args(["--awk", "-c", "$l.startswith('a') { print($l) }"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn()
@@ -29,7 +29,7 @@ fn awk_flag_filters_input() {
 #[test]
 fn awk_directive_enables_mode() {
     let exe = env!("CARGO_BIN_EXE_snail");
-    let source = "#!snail awk\nBEGIN { print('start') }\nline.endswith('!')\nEND { print('done') }";
+    let source = "#!snail awk\nBEGIN { print('start') }\n$l.endswith('!')\nEND { print('done') }";
 
     let mut child = Command::new(exe)
         .args(["-c", source])
@@ -61,7 +61,7 @@ fn awk_directive_enables_mode() {
 #[test]
 fn awk_regex_pattern_sets_match() {
     let exe = env!("CARGO_BIN_EXE_snail");
-    let source = "/a.+c/ { print(match.group(0)) }";
+    let source = "/a.+c/ { print($m.group(0)) }";
 
     let mut child = Command::new(exe)
         .args(["--awk", "-c", source])

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -29,6 +29,14 @@ fn reports_parse_error_with_location() {
 }
 
 #[test]
+fn rejects_user_defined_dollar_identifiers() {
+    let source = "$bad = 1";
+    let err = parse_program(source).expect_err("$ identifiers are injected");
+    let message = err.to_string();
+    assert!(message.contains("$bad"));
+}
+
+#[test]
 fn parses_if_elif_else_chain() {
     let source = r#"
 if x { y = 1 }


### PR DESCRIPTION
## Summary
- document that awk-mode `$` variables are language-injected, add a parser test, and guard against user-defined `$` identifiers
- tighten the awk grammar so rules must contain a pattern or block, avoiding empty entries from trailing separators
- expand Vim syntax highlighting for injected `$` names and keep the awk example consistent

## Testing
- cargo fmt
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956d7ae4e5c8325982583f4c4e1dbc6)