### PR TITLE
Make cargo test fail on warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
       - name: clippy
         run: cargo clippy -- -D warnings
       - name: test
-        run: cargo test
+        run: RUSTFLAGS="-D warnings" cargo test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: test build install
 test:
 	cargo fmt --check
 	cargo clippy -- -D warnings
-	cargo test
+	RUSTFLAGS="-D warnings" cargo test
 
 # Build release binary
 build:

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -665,7 +665,7 @@ fn json_with_structured_accessor_from_stdin() {
         .spawn()
         .expect("spawn snail");
 
-    let stdin = child.stdin.as_mut().expect("get stdin");
+    let mut stdin = child.stdin.take().expect("get stdin");
     stdin.write_all(b"{\"test\": 123}").expect("write to stdin");
     drop(stdin);
 


### PR DESCRIPTION
- Add RUSTFLAGS="-D warnings" to cargo test in Makefile
- Add RUSTFLAGS="-D warnings" to cargo test in GitHub CI
- Fix dropping-references warning in tests/cli.rs by taking ownership of stdin

This ensures warnings are treated as errors during testing, keeping the codebase clean and preventing warning accumulation.