### PR TITLE
Fix CI running twice on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Previously CI would run twice for PRs - once on push and once on pull_request. Now it only runs on pull_request events for PRs, and on push events for main branch only.