### PR TITLE
docs: add comprehensive README files for all workspace crates

### DIFF
--- a/crates/snail-ast/README.md
+++ b/crates/snail-ast/README.md
@@ -1,0 +1,33 @@
+# snail-ast
+
+Core AST (Abstract Syntax Tree) data structures for the Snail programming language.
+
+## Purpose
+
+This crate defines the foundational data structures that represent Snail programs after parsing. It contains pure data types with no dependencies on other crates, making it the base layer of the Snail compilation pipeline.
+
+## Key Components
+
+- **Program**: Top-level representation of a Snail program containing a list of statements
+- **Stmt**: Enumeration of all statement types (if, while, for, def, class, try, etc.)
+- **Expr**: Enumeration of all expression types (literals, operators, calls, etc.)
+- **AwkProgram**: Specialized AST for awk mode with BEGIN/END blocks and pattern/action rules
+- **AwkRule**: Pattern/action pairs used in awk mode
+- **SourceSpan/SourcePos**: Source location tracking for error reporting
+
+## Dependencies
+
+None - this crate has no dependencies and provides pure data structures.
+
+## Used By
+
+- **snail-python-ast**: Uses `SourceSpan` and `StringDelimiter` for its own AST nodes
+- **snail-error**: Uses `SourceSpan` for error reporting with source locations
+- **snail-parser**: Produces `Program` and `AwkProgram` as output
+- **snail-lower**: Consumes Snail AST and transforms it to Python AST
+- **snail-codegen**: Uses `StringDelimiter` for string literal formatting
+- **snail-core**: Re-exports all types for the unified API
+
+## Design
+
+All AST nodes carry `SourceSpan` information to enable precise error messages and tracebacks that point to the original Snail source code.

--- a/crates/snail-cli/README.md
+++ b/crates/snail-cli/README.md
@@ -1,0 +1,64 @@
+# snail-cli
+
+Command-line interface for the Snail programming language.
+
+## Purpose
+
+This crate provides the `snail` executable that users interact with to run Snail programs. It handles command-line argument parsing, source file reading, compilation, and execution of generated Python code via subprocess.
+
+## Key Features
+
+- **File execution**: `snail -f script.snail`
+- **One-liner execution**: `snail 'print("hello")'`
+- **Awk mode**: `snail --awk -f script.snail`
+- **Debug mode**: `snail --python` shows generated Python code
+- **Auto-print control**: `-P` flag disables auto-print of last expression
+- **Argument passing**: Arguments after source are passed to the Snail script
+- **Virtual environment support**: Automatically respects active Python virtual environments
+
+## Command-Line Interface
+
+```
+snail [options] -f <file> [args]...
+snail [options] <code> [args]...
+```
+
+Options:
+- `-f <file>`: Run a source file
+- `-a, --awk`: Enable awk mode
+- `-p, --python`: Print generated Python instead of executing
+- `-P, --no-print`: Disable auto-printing of last expression
+- `-v, --version`: Show version information
+
+## Execution Model
+
+1. Parse command-line arguments using clap
+2. Read source from file or command-line argument
+3. Compile Snail source to Python using `snail-core`
+4. If `--python` flag: print Python code and exit
+5. Otherwise: execute Python code via subprocess
+   - Uses `python3` by default (configurable via `PYTHON` env var)
+   - Pipes generated Python to subprocess stdin
+   - Forwards stdout/stderr to user
+   - Returns subprocess exit code
+
+## Dependencies
+
+- **snail-core**: Uses compilation API (`compile_snail_source_with_auto_print`, `format_snail_error`)
+- **clap**: Command-line argument parsing with derive macros
+- **pest/pest_derive**: Inherited for compatibility (may be removable)
+
+## Used By
+
+- End users invoke the `snail` binary directly
+- Can be called from shell scripts with shebangs: `#!/usr/bin/env snail --awk -f`
+
+## Design
+
+The CLI uses subprocess execution to run generated Python code, which:
+- Respects virtual environments automatically
+- Avoids pyo3 runtime dependencies in the CLI binary
+- Supports configurable Python interpreter via `PYTHON` env var
+- Provides clean separation between compilation and execution
+
+The binary name is `snail`, built from this crate's main.rs.

--- a/crates/snail-codegen/README.md
+++ b/crates/snail-codegen/README.md
@@ -1,0 +1,57 @@
+# snail-codegen
+
+Python code generation from Python AST.
+
+## Purpose
+
+This crate is the final stage of the Snail compilation pipeline. It converts Python AST nodes into executable Python source code strings, handling proper indentation, syntax formatting, and injection of runtime helper functions.
+
+## Key Components
+
+- **python_source()**: Converts a `PyModule` to Python source code
+- **python_source_with_auto_print()**: Generates code with optional auto-print of last expression
+- **PythonWriter**: Internal writer that manages indentation and code generation
+- **Helper injection functions**:
+  - `write_snail_try_helper()`: Injects the compact try (`?`) helper function
+  - `write_snail_regex_helpers()`: Injects regex search and compile helpers
+  - `write_snail_subprocess_helpers()`: Injects subprocess capture/status classes
+  - `write_structured_accessor_helpers()`: Injects structured data accessor classes and vendored jmespath
+  - `write_vendored_jmespath()`: Embeds jmespath library for structured queries
+
+## Smart Helper Injection
+
+The codegen scans the Python AST to detect which Snail features are used, and only injects the necessary helper functions:
+- Only inject try helper if `__snail_compact_try` is referenced
+- Only inject regex helpers if `__snail_regex_search` or `__snail_regex_compile` are used
+- Only inject subprocess helpers if subprocess classes are used
+- Only inject structured accessor helpers if `__SnailStructuredAccessor` or `json()` are used
+
+This minimizes generated code size and avoids unused imports.
+
+## Auto-Print Feature
+
+When `auto_print_last` is true, the codegen wraps the last expression statement to:
+1. Capture the result in a temporary variable
+2. Print strings directly
+3. Pretty-print non-None objects using `pprint`
+4. Do nothing if the result is None
+5. Skip auto-print if the statement was terminated with semicolon
+
+This provides REPL-like behavior for CLI one-liners.
+
+## Dependencies
+
+- **snail-ast**: Uses `StringDelimiter` for proper string formatting
+- **snail-python-ast**: Consumes `PyModule`, `PyStmt`, `PyExpr` and generates source
+- **snail-lower**: Uses helper constant names (e.g., `SNAIL_TRY_HELPER`)
+
+## Used By
+
+- **snail-core**: Calls `python_source()` or `python_source_with_auto_print()` to generate final output
+- Tests validate that generated Python code is syntactically correct
+
+## Design
+
+The code generator maintains proper Python indentation (4 spaces) and formats all Python constructs correctly. It handles edge cases like single-element tuples `(x,)`, raw strings, f-strings with escaping, and elif chains.
+
+The vendored jmespath library is embedded as inline string data to avoid runtime dependencies, making Snail programs self-contained.

--- a/crates/snail-core/README.md
+++ b/crates/snail-core/README.md
@@ -1,0 +1,62 @@
+# snail-core
+
+Unified compilation API for the Snail programming language.
+
+## Purpose
+
+This crate serves as the main entry point for Snail compilation. It re-exports all types from the workspace crates and provides high-level compilation functions that orchestrate the complete pipeline from source code to executable Python.
+
+## Key Components
+
+- **compile_snail_source()**: One-step compilation from Snail source to Python source
+- **compile_snail_source_with_auto_print()**: Compilation with optional auto-print for CLI mode
+- Re-exports from all workspace crates:
+  - `snail-ast`: All AST types
+  - `snail-python-ast`: All Python AST types
+  - `snail-error`: Error types and formatting
+  - `snail-parser`: Parsing functions
+  - `snail-lower`: Lowering functions
+  - `snail-codegen`: Code generation functions
+
+## Compilation Pipeline
+
+The `compile_snail_source()` function orchestrates the complete compilation:
+
+1. **Parse**: `parse_program()` or `parse_awk_program()` → Snail AST
+2. **Lower**: `lower_program()` or `lower_awk_program()` → Python AST
+3. **Codegen**: `python_source()` → Python source string
+
+Each stage can fail with appropriate error types (`ParseError` or `LowerError`), wrapped in the unified `SnailError` type.
+
+## Mode Selection
+
+The `CompileMode` enum determines parsing and compilation behavior:
+- **CompileMode::Snail**: Regular Snail mode with curly-brace syntax
+- **CompileMode::Awk**: Awk mode with pattern/action processing
+
+## Auto-Print Feature
+
+When `auto_print_last` is true:
+- In regular mode: Last expression is captured and pretty-printed
+- In awk mode: Auto-print is handled at the block level during lowering
+
+This enables REPL-like behavior for interactive use and CLI one-liners.
+
+## Dependencies
+
+- **snail-ast**: Core AST types
+- **snail-python-ast**: Python AST types
+- **snail-error**: Error handling
+- **snail-parser**: Parsing logic
+- **snail-lower**: AST transformation
+- **snail-codegen**: Python code generation
+
+## Used By
+
+- **snail-cli**: Uses the compilation API to compile and execute Snail programs
+- Library consumers can use this crate to embed Snail compilation in other tools
+- Tests validate end-to-end compilation correctness
+
+## Design
+
+This crate provides a clean, minimal API surface for Snail compilation. Users only need to import `snail-core` to access all compilation functionality without managing individual workspace crates.

--- a/crates/snail-error/README.md
+++ b/crates/snail-error/README.md
@@ -1,0 +1,47 @@
+# snail-error
+
+Error types and formatting utilities for the Snail compiler.
+
+## Purpose
+
+This crate provides unified error handling across all stages of Snail compilation. It defines error types for parsing and lowering failures, along with formatting utilities that produce user-friendly error messages with source location context.
+
+## Key Components
+
+- **ParseError**: Errors from the parsing stage (syntax errors, invalid tokens, etc.)
+- **LowerError**: Errors from the lowering/transformation stage
+- **SnailError**: Unified error enum wrapping both parse and lower errors
+- **format_snail_error()**: Formats errors with file name and source context
+- **format_parse_error()**: Specialized formatting for parse errors with line numbers and carets
+
+## Dependencies
+
+- **snail-ast**: Uses `SourceSpan` to provide precise error locations
+
+## Used By
+
+- **snail-parser**: Returns `ParseError` when parsing fails
+- **snail-lower**: Returns `LowerError` when transformation fails
+- **snail-core**: Uses `SnailError` as the unified Result type for compilation
+- **snail-cli**: Uses `format_snail_error()` to display errors to users
+
+## Error Format
+
+Parse errors include:
+- Error message describing the problem
+- File name and line:column location
+- The problematic line of source code
+- A caret (^) pointing to the error location
+
+Example:
+```
+error: unexpected token
+--> script.snail:5:12
+ |
+5 | if x == {
+ |            ^
+```
+
+## Design
+
+All error types implement the standard `Error` trait and provide Display implementations. The `SourceSpan` integration enables precise error reporting that helps users quickly locate and fix issues in their Snail code.

--- a/crates/snail-lower/README.md
+++ b/crates/snail-lower/README.md
@@ -1,0 +1,56 @@
+# snail-lower
+
+AST transformation layer that lowers Snail AST to Python AST.
+
+## Purpose
+
+This crate is the semantic transformation core of the Snail compiler. It takes Snail AST nodes and transforms them into equivalent Python AST nodes, handling all Snail-specific features by generating appropriate Python code patterns and helper function calls.
+
+## Key Components
+
+- **lower_program()**: Transforms a regular `Program` to `PyModule`
+- **lower_awk_program()**: Transforms an `AwkProgram` to `PyModule` with awk runtime
+- **lower_awk_program_with_auto_print()**: Awk lowering with optional auto-print
+- Helper constants for generated Python code:
+  - `SNAIL_TRY_HELPER`: Name for the `?` operator helper function
+  - `SNAIL_SUBPROCESS_CAPTURE_CLASS`: Class for `$(cmd)` subprocess capture
+  - `SNAIL_SUBPROCESS_STATUS_CLASS`: Class for `@(cmd)` subprocess status
+  - `SNAIL_REGEX_SEARCH/COMPILE`: Regex helper functions
+  - `SNAIL_STRUCTURED_ACCESSOR_CLASS`: Class for structured data queries
+
+## Snail Feature Transformations
+
+- **Compact try operator** (`expr?`): Transformed into `__snail_compact_try(lambda: expr)` call
+- **Compact try with fallback** (`expr ? fallback`): Transformed with fallback lambda
+- **Subprocess capture** (`$(cmd)`): Transformed into `__SnailSubprocessCapture(cmd)` instance
+- **Subprocess status** (`@(cmd)`): Transformed into `__SnailSubprocessStatus(cmd)` instance
+- **Regex expressions** (`/pattern/`): Transformed into `__snail_regex_compile(pattern)` call
+- **Regex matching** (`string in /pattern/`): Transformed into `__snail_regex_search(string, pattern)` call
+- **Structured accessors** (`$[query]`): Transformed into `__SnailStructuredAccessor(query)` instance
+- **Awk variables**: `$l`, `$f`, `$n`, `$fn`, `$p`, `$m` mapped to Python variable names
+
+## Awk Mode Lowering
+
+When lowering awk programs, generates a complete Python program that:
+1. Imports `sys` for accessing command-line arguments and stdin
+2. Executes BEGIN blocks before processing input
+3. Creates a main loop that reads lines from files or stdin
+4. Updates awk variables (`$l`, `$f`, `$n`, etc.) for each line
+5. Evaluates patterns and executes actions for matching lines
+6. Executes END blocks after all input is processed
+
+## Dependencies
+
+- **snail-ast**: Consumes Snail `Program` and `AwkProgram`
+- **snail-python-ast**: Produces Python `PyModule` and related nodes
+- **snail-error**: Returns `LowerError` on transformation failures
+
+## Used By
+
+- **snail-codegen**: Consumes the Python AST to generate source code
+- **snail-core**: Calls lowering functions as part of the compilation pipeline
+- Tests validate transformation correctness
+
+## Design
+
+The lowering process preserves Python semantics exactly - only syntax differs. All `SourceSpan` information is preserved through the transformation to enable accurate error reporting in the generated Python code.

--- a/crates/snail-parser/README.md
+++ b/crates/snail-parser/README.md
@@ -1,0 +1,40 @@
+# snail-parser
+
+Pest-based parser for the Snail programming language.
+
+## Purpose
+
+This crate contains the parser that transforms Snail source code into a Snail AST. It uses the Pest parser generator with a PEG (Parsing Expression Grammar) to recognize Snail syntax and produce structured AST nodes with source location information.
+
+## Key Components
+
+- **parse_program()**: Parses regular Snail code into a `Program`
+- **parse_awk_program()**: Parses awk-mode Snail code into an `AwkProgram`
+- **snail.pest**: PEG grammar defining Snail's syntax
+- **SnailParser**: Pest-generated parser from the grammar
+
+## Grammar File
+
+The `snail.pest` file defines all of Snail's syntax rules including:
+- Curly-brace block structure
+- Expression syntax (operators, calls, literals, etc.)
+- Statement types (if/while/for/try/with/def/class)
+- Snail-specific features (?, $(), @(), regex, structured accessors)
+- Awk mode syntax (BEGIN/END blocks, pattern/action rules)
+- String interpolation with {expr}
+
+## Dependencies
+
+- **snail-ast**: Produces `Program` and `AwkProgram` as output
+- **snail-error**: Returns `ParseError` on syntax errors
+- **pest**: Parser generator library (2.7)
+- **pest_derive**: Procedural macro for grammar compilation
+
+## Used By
+
+- **snail-core**: Calls `parse_program()` or `parse_awk_program()` as the first compilation stage
+- Tests validate AST structure from various Snail source inputs
+
+## Design
+
+The parser preserves complete source location information (`SourceSpan`) for every AST node, enabling precise error messages and tracebacks. It handles all Snail syntax including string interpolation in multiple string forms (quotes, regex, subprocess).

--- a/crates/snail-python-ast/README.md
+++ b/crates/snail-python-ast/README.md
@@ -1,0 +1,32 @@
+# snail-python-ast
+
+Python AST (Abstract Syntax Tree) data structures for Snail's compilation target.
+
+## Purpose
+
+This crate defines the intermediate representation used by Snail when compiling to Python. It provides Python-specific AST nodes that mirror Python's syntax and semantics, serving as the bridge between Snail AST and executable Python code.
+
+## Key Components
+
+- **PyModule**: Top-level Python module containing statements
+- **PyStmt**: Python statement types (If, While, For, FunctionDef, ClassDef, etc.)
+- **PyExpr**: Python expression types (Name, Number, String, Call, etc.)
+- **PyParameter**: Function parameter representations
+- **PyArgument**: Function call argument types (positional, keyword, *args, **kwargs)
+- **PyImportName**: Import statement components
+- **PyWithItem**: Context manager items for with statements
+- **PyExceptHandler**: Exception handler clauses
+
+## Dependencies
+
+- **snail-ast**: Uses `SourceSpan` for source location tracking and `StringDelimiter` for string literal formatting
+
+## Used By
+
+- **snail-lower**: Produces Python AST as its output when transforming Snail AST
+- **snail-codegen**: Consumes Python AST and generates executable Python source code
+- **snail-core**: Re-exports all types for the unified API
+
+## Design
+
+Python AST nodes preserve `SourceSpan` information from the original Snail source, enabling accurate error reporting even after transformation. The structure closely mirrors Python's actual AST to ensure semantic correctness of the generated code.


### PR DESCRIPTION
Add detailed README.md files to all 8 workspace crates documenting:
- Purpose and key components of each crate
- Dependencies and what uses each crate
- Design decisions and implementation details

Crates documented:
- snail-ast: Core Snail AST data structures
- snail-python-ast: Python AST data structures
- snail-error: Error types and formatting
- snail-parser: Pest-based Snail parser
- snail-lower: AST transformation (Snail → Python)
- snail-codegen: Python code generation
- snail-core: Unified compilation API
- snail-cli: Command-line interface

These READMEs provide a clear map of the codebase architecture
and help developers understand how the crates interact.