### PR TITLE
feat: support nested quotes in f-strings

### DIFF
--- a/crates/snail-parser/src/snail.pest
+++ b/crates/snail-parser/src/snail.pest
@@ -210,8 +210,15 @@ string = @{ raw_prefix? ~ (triple_double | triple_single | double_string | singl
 raw_prefix = { "r" }
 triple_double = { "\"\"\"" ~ (!"\"\"\"" ~ ANY)* ~ "\"\"\"" }
 triple_single = { "'''" ~ (!"'''" ~ ANY)* ~ "'''" }
-double_string = { "\"" ~ ( "\\\"" | !"\"" ~ ANY )* ~ "\"" }
-single_string = { "'" ~ ( "\\'" | !"'" ~ ANY )* ~ "'" }
+double_string = { "\"" ~ double_string_content ~ "\"" }
+double_string_content = @{ (brace_block | escaped_char | double_string_char)* }
+single_string = { "'" ~ single_string_content ~ "'" }
+single_string_content = @{ (brace_block | escaped_char | single_string_char)* }
+brace_block = { "{" ~ brace_content* ~ "}" }
+brace_content = _{ brace_block | (!"}" ~ !"{" ~ ANY) }
+escaped_char = { "\\" ~ ANY }
+double_string_char = { (!("\\" | "\"" | "{") ~ ANY) }
+single_string_char = { (!("\\" | "'" | "{") ~ ANY) }
 regex = @{ "/" ~ ( "\\/" | !"/" ~ ANY )* ~ "/" }
 
 // Identifiers: must not be keywords


### PR DESCRIPTION
Enable f-strings to contain expressions with nested string literals that use
the same quote type as the outer string. For example:
  "test {"inner".method()} more"

Implementation:
- Updated Pest grammar to recognize balanced {expr} blocks inside strings,
  allowing quotes inside interpolation expressions
- Enhanced Python code generation to intelligently choose quote delimiters:
  * Uses single quotes if expressions contain double-quoted strings
  * Uses double quotes if expressions contain single-quoted strings
  * Uses triple-double-quotes if expressions contain both types
- Added brace_block rule to handle nested braces in string interpolations

This fixes parsing errors when f-string expressions contain string literals
or complex expressions like list/dict literals with quoted elements.