### PR TITLE
Rename AGENTS documentation header to remove Claude-specific wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# AGENTS.md
 
 This file provides guidance to agents when working with code in this repository.
 


### PR DESCRIPTION
### Motivation
- Remove a Claude-specific header and make the repository agent guidance generic and consistent.
- Ensure the top-level documentation file uses a neutral `AGENTS.md` header without altering content semantics.

### Description
- Replace the top-line header `# CLAUDE.md` with `# AGENTS.md` in `AGENTS.md`.
- No other documentation or code changes were made.

### Testing
- Ran `make test` (which includes `cargo fmt --check`, `RUSTFLAGS="-D warnings" cargo build`, `cargo build --features run-proptests`, `cargo clippy -- -D warnings`, `cargo test`, and `python -m pytest python/tests`) and it passed.
- All automated Rust and Python tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b910c148832598405b9c0e21ba28)