### PR TITLE
error on awk-only identifiers in regular mode

### DIFF
--- a/crates/snail-parser/src/lib.rs
+++ b/crates/snail-parser/src/lib.rs
@@ -13,7 +13,7 @@ mod util;
 
 use awk::parse_awk_rule;
 use stmt::{parse_block, parse_stmt_list};
-use util::{full_span, parse_error_from_pest};
+use util::{error_with_span, full_span, parse_error_from_pest};
 
 #[derive(Parser)]
 #[grammar = "snail.pest"]
@@ -32,7 +32,9 @@ pub fn parse_program(source: &str) -> Result<Program, ParseError> {
             stmts = parse_stmt_list(inner, source)?;
         }
     }
-    Ok(Program { stmts, span })
+    let program = Program { stmts, span };
+    validate_no_awk_syntax(&program, source)?;
+    Ok(program)
 }
 
 pub fn parse_awk_program(source: &str) -> Result<AwkProgram, ParseError> {
@@ -82,4 +84,334 @@ pub fn parse_awk_program(source: &str) -> Result<AwkProgram, ParseError> {
         end_blocks,
         span,
     })
+}
+
+const AWK_ONLY_NAMES: [&str; 6] = ["$l", "$f", "$n", "$fn", "$p", "$m"];
+const AWK_ONLY_MESSAGE: &str = "awk variables are only valid in awk mode; use --awk";
+
+fn validate_no_awk_syntax(program: &Program, source: &str) -> Result<(), ParseError> {
+    for stmt in &program.stmts {
+        validate_stmt(stmt, source)?;
+    }
+    Ok(())
+}
+
+fn validate_stmt(stmt: &Stmt, source: &str) -> Result<(), ParseError> {
+    match stmt {
+        Stmt::If {
+            cond,
+            body,
+            elifs,
+            else_body,
+            ..
+        } => {
+            validate_expr(cond, source)?;
+            validate_block(body, source)?;
+            for (elif_cond, elif_body) in elifs {
+                validate_expr(elif_cond, source)?;
+                validate_block(elif_body, source)?;
+            }
+            if let Some(body) = else_body {
+                validate_block(body, source)?;
+            }
+        }
+        Stmt::While {
+            cond,
+            body,
+            else_body,
+            ..
+        } => {
+            validate_expr(cond, source)?;
+            validate_block(body, source)?;
+            if let Some(body) = else_body {
+                validate_block(body, source)?;
+            }
+        }
+        Stmt::For {
+            target,
+            iter,
+            body,
+            else_body,
+            ..
+        } => {
+            validate_assign_target(target, source)?;
+            validate_expr(iter, source)?;
+            validate_block(body, source)?;
+            if let Some(body) = else_body {
+                validate_block(body, source)?;
+            }
+        }
+        Stmt::Def { params, body, .. } => {
+            for param in params {
+                validate_param(param, source)?;
+            }
+            validate_block(body, source)?;
+        }
+        Stmt::Class { body, .. } => {
+            validate_block(body, source)?;
+        }
+        Stmt::Try {
+            body,
+            handlers,
+            else_body,
+            finally_body,
+            ..
+        } => {
+            validate_block(body, source)?;
+            for handler in handlers {
+                validate_except_handler(handler, source)?;
+            }
+            if let Some(body) = else_body {
+                validate_block(body, source)?;
+            }
+            if let Some(body) = finally_body {
+                validate_block(body, source)?;
+            }
+        }
+        Stmt::With { items, body, .. } => {
+            for item in items {
+                validate_with_item(item, source)?;
+            }
+            validate_block(body, source)?;
+        }
+        Stmt::Return { value, .. } => {
+            if let Some(value) = value {
+                validate_expr(value, source)?;
+            }
+        }
+        Stmt::Raise { value, from, .. } => {
+            if let Some(value) = value {
+                validate_expr(value, source)?;
+            }
+            if let Some(from) = from {
+                validate_expr(from, source)?;
+            }
+        }
+        Stmt::Assert { test, message, .. } => {
+            validate_expr(test, source)?;
+            if let Some(message) = message {
+                validate_expr(message, source)?;
+            }
+        }
+        Stmt::Delete { targets, .. } => {
+            for target in targets {
+                validate_assign_target(target, source)?;
+            }
+        }
+        Stmt::Import { .. }
+        | Stmt::ImportFrom { .. }
+        | Stmt::Break { .. }
+        | Stmt::Continue { .. }
+        | Stmt::Pass { .. } => {}
+        Stmt::Assign { targets, value, .. } => {
+            for target in targets {
+                validate_assign_target(target, source)?;
+            }
+            validate_expr(value, source)?;
+        }
+        Stmt::Expr { value, .. } => {
+            validate_expr(value, source)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_block(block: &[Stmt], source: &str) -> Result<(), ParseError> {
+    for stmt in block {
+        validate_stmt(stmt, source)?;
+    }
+    Ok(())
+}
+
+fn validate_with_item(item: &WithItem, source: &str) -> Result<(), ParseError> {
+    validate_expr(&item.context, source)?;
+    if let Some(target) = &item.target {
+        validate_assign_target(target, source)?;
+    }
+    Ok(())
+}
+
+fn validate_except_handler(handler: &ExceptHandler, source: &str) -> Result<(), ParseError> {
+    if let Some(expr) = &handler.type_name {
+        validate_expr(expr, source)?;
+    }
+    validate_block(&handler.body, source)?;
+    Ok(())
+}
+
+fn validate_param(param: &Parameter, source: &str) -> Result<(), ParseError> {
+    match param {
+        Parameter::Regular { default, .. } => {
+            if let Some(default) = default {
+                validate_expr(default, source)?;
+            }
+        }
+        Parameter::VarArgs { .. } | Parameter::KwArgs { .. } => {}
+    }
+    Ok(())
+}
+
+fn validate_argument(arg: &Argument, source: &str) -> Result<(), ParseError> {
+    match arg {
+        Argument::Positional { value, .. }
+        | Argument::Keyword { value, .. }
+        | Argument::Star { value, .. }
+        | Argument::KwStar { value, .. } => validate_expr(value, source),
+    }
+}
+
+fn validate_assign_target(target: &AssignTarget, source: &str) -> Result<(), ParseError> {
+    match target {
+        AssignTarget::Name { .. } => Ok(()),
+        AssignTarget::Attribute { value, .. } => validate_expr(value, source),
+        AssignTarget::Index { value, index, .. } => {
+            validate_expr(value, source)?;
+            validate_expr(index, source)
+        }
+    }
+}
+
+fn validate_expr(expr: &Expr, source: &str) -> Result<(), ParseError> {
+    match expr {
+        Expr::Name { name, span } => {
+            if AWK_ONLY_NAMES.contains(&name.as_str()) {
+                return Err(error_with_span(AWK_ONLY_MESSAGE, span.clone(), source));
+            }
+        }
+        Expr::FieldIndex { span, .. } => {
+            return Err(error_with_span(AWK_ONLY_MESSAGE, span.clone(), source));
+        }
+        Expr::FString { parts, .. } => {
+            for part in parts {
+                validate_fstring_part(part, source)?;
+            }
+        }
+        Expr::Unary { expr, .. } => {
+            validate_expr(expr, source)?;
+        }
+        Expr::Binary { left, right, .. } => {
+            validate_expr(left, source)?;
+            validate_expr(right, source)?;
+        }
+        Expr::Compare {
+            left, comparators, ..
+        } => {
+            validate_expr(left, source)?;
+            for expr in comparators {
+                validate_expr(expr, source)?;
+            }
+        }
+        Expr::IfExpr {
+            test, body, orelse, ..
+        } => {
+            validate_expr(test, source)?;
+            validate_expr(body, source)?;
+            validate_expr(orelse, source)?;
+        }
+        Expr::TryExpr { expr, fallback, .. } => {
+            validate_expr(expr, source)?;
+            if let Some(fallback) = fallback {
+                validate_expr(fallback, source)?;
+            }
+        }
+        Expr::Compound { expressions, .. } => {
+            for expr in expressions {
+                validate_expr(expr, source)?;
+            }
+        }
+        Expr::Regex { pattern, .. } => {
+            validate_regex_pattern(pattern, source)?;
+        }
+        Expr::RegexMatch { value, pattern, .. } => {
+            validate_expr(value, source)?;
+            validate_regex_pattern(pattern, source)?;
+        }
+        Expr::Subprocess { parts, .. } => {
+            for part in parts {
+                if let SubprocessPart::Expr(expr) = part {
+                    validate_expr(expr, source)?;
+                }
+            }
+        }
+        Expr::StructuredAccessor { .. }
+        | Expr::Number { .. }
+        | Expr::String { .. }
+        | Expr::Bool { .. }
+        | Expr::None { .. } => {}
+        Expr::Call { func, args, .. } => {
+            validate_expr(func, source)?;
+            for arg in args {
+                validate_argument(arg, source)?;
+            }
+        }
+        Expr::Attribute { value, .. } => {
+            validate_expr(value, source)?;
+        }
+        Expr::Index { value, index, .. } => {
+            validate_expr(value, source)?;
+            validate_expr(index, source)?;
+        }
+        Expr::Paren { expr, .. } => {
+            validate_expr(expr, source)?;
+        }
+        Expr::List { elements, .. } | Expr::Tuple { elements, .. } | Expr::Set { elements, .. } => {
+            for expr in elements {
+                validate_expr(expr, source)?;
+            }
+        }
+        Expr::Dict { entries, .. } => {
+            for (key, value) in entries {
+                validate_expr(key, source)?;
+                validate_expr(value, source)?;
+            }
+        }
+        Expr::Slice { start, end, .. } => {
+            if let Some(start) = start {
+                validate_expr(start, source)?;
+            }
+            if let Some(end) = end {
+                validate_expr(end, source)?;
+            }
+        }
+        Expr::ListComp {
+            element, iter, ifs, ..
+        } => {
+            validate_expr(element, source)?;
+            validate_expr(iter, source)?;
+            for expr in ifs {
+                validate_expr(expr, source)?;
+            }
+        }
+        Expr::DictComp {
+            key,
+            value,
+            iter,
+            ifs,
+            ..
+        } => {
+            validate_expr(key, source)?;
+            validate_expr(value, source)?;
+            validate_expr(iter, source)?;
+            for expr in ifs {
+                validate_expr(expr, source)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_regex_pattern(pattern: &RegexPattern, source: &str) -> Result<(), ParseError> {
+    if let RegexPattern::Interpolated(parts) = pattern {
+        for part in parts {
+            validate_fstring_part(part, source)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_fstring_part(part: &FStringPart, source: &str) -> Result<(), ParseError> {
+    if let FStringPart::Expr(expr) = part {
+        validate_expr(expr, source)?;
+    }
+    Ok(())
 }

--- a/crates/snail-parser/tests/parser.rs
+++ b/crates/snail-parser/tests/parser.rs
@@ -84,6 +84,24 @@ fn rejects_user_defined_dollar_identifiers() {
 }
 
 #[test]
+fn rejects_awk_only_variables_in_regular_mode() {
+    let source = "value = $l";
+    let err = parse_program(source).expect_err("awk identifiers should fail");
+    let message = err.to_string();
+    assert!(message.contains("$l"));
+    assert!(message.contains("--awk"));
+}
+
+#[test]
+fn rejects_awk_field_indices_in_regular_mode() {
+    let source = "value = $1";
+    let err = parse_program(source).expect_err("awk fields should fail");
+    let message = err.to_string();
+    assert!(message.contains("$1"));
+    assert!(message.contains("--awk"));
+}
+
+#[test]
 fn parses_if_elif_else_chain() {
     let source = r#"
 if x { y = 1 }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -229,7 +229,8 @@ While processing, Snail populates awk-style variables:
 - `$m`: the last regex match object.
 
 These `$` variables are injected by the language; user-defined identifiers
-cannot start with `$`.
+cannot start with `$`. They are only available in awk mode—using them in
+regular Snail code requires `--awk`.
 
 Input files come from `sys.argv[1:]`; when none are provided, awk mode reads
 stdin. Pass `--` to the CLI to forward filenames or other arguments into the

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -48,3 +48,9 @@ def test_awk_mode(
     assert main(["--awk", "/foo/ { print($l) }"]) == 0
     captured = capsys.readouterr()
     assert captured.out == "foo\n"
+
+
+def test_awk_identifiers_require_awk_mode() -> None:
+    with pytest.raises(SyntaxError) as excinfo:
+        main(["print($l)"])
+    assert "--awk" in str(excinfo.value)


### PR DESCRIPTION
Reject awk variables and field indexes outside --awk and document the restriction.