### PR TITLE
Clarify pipeline callable semantics in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Built-in variables: `$l` (line), `$f` (fields), `$n` (line number), `$fn` (per-f
 
 ### Pipeline Operator
 
-The `|` operator enables data pipelining through objects that implement `__pipeline__`:
+The `|` operator enables data pipelining through pipeline-aware callables:
 
 ```snail
 # Pipe data to subprocess stdin
@@ -101,7 +101,7 @@ output = "foo\nbar" | $(grep foo) | $(wc -l)
 
 # Custom pipeline handlers
 class Doubler {
-    def __pipeline__(self, x) { return x * 2 }
+    def __call__(self, x) { return x * 2 }
 }
 doubled = 21 | Doubler()  # yields 42
 
@@ -111,7 +111,15 @@ joined = ["a", "b"] | join(" ")  # yields "a b"
 # Use placeholders to control where piped values land in calls
 greeting = "World" | greet("Hello ", _)  # greet("Hello ", "World")
 excited = "World" | greet(_, "!")        # greet("World", "!")
+formal = "World" | greet("Hello ", suffix=_)  # greet("Hello ", "World")
 ```
+
+When a pipeline targets a call expression, the left-hand value is passed to the
+resulting callable (`data | join(" ")` calls the function returned by
+`join(" ")`). If the call includes a single `_` placeholder, Snail substitutes
+the piped value at that position (including keyword arguments). Only one
+placeholder is allowed in a piped call. Outside of pipeline calls, `_` remains a
+normal identifier.
 
 ### JSON Queries with JMESPath
 


### PR DESCRIPTION
### Motivation

- Remove stale references to the `__pipeline__` dunder method and align documentation with the runtime semantics where pipeline targets are callables.
- Explain how the `|` operator behaves when piping into call expressions and how the placeholder `_` is interpreted in that context.

### Description

- Replace mentions and examples of `__pipeline__` with callable semantics and `__call__` in `README.md` and `docs/REFERENCE.md`.
- Update the `Doubler` example to use `def __call__` and adjust other examples to show piping into callables (including `greet(...)` examples with `_`).
- Reword subprocess and JSON accessor sections to describe them as callables that accept piped input and update the `$[query]` wording to indicate it "produces a callable".
- Add a short paragraph clarifying that when piping into a call expression the left-hand value is passed to the callable result and that a single `_` placeholder (including in keyword args) is substituted there.

### Testing

- Ran `make test` which completed successfully with all checks passing.
- Ran Python CLI tests via `python -m pytest python/tests` which passed (`10 passed`).
- Ran the Rust test suite via `cargo test` as part of `make test` and the relevant parser and unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69691302ba588325a0b14d4dae22cd8e)