### PR TITLE
Replace BEGIN/END blocks with -b/-e CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,17 @@ semicolons are optional. You can separate statements with newlines.
 
 Process files line-by-line with familiar awk semantics:
 
-```snail-awk("5\n4\n3\n2\n1\nbanana\n")
-BEGIN { total = 0 }
-/^[0-9]+/ { total = total + int($1) }
-END { print("Sum:", total); assert total == 15}
+```snail-awk("hello world\nfoo bar\n")
+/hello/ { print("matched:", $0) }
+{ print($1, "->", $2) }
 ```
 
 Built-in variables: `$0` (line), `$1`, `$2` etc (access fields), `$n` (line number), `$fn` (per-file line number), `$p` (file path), `$m` (last match).
+
+Begin/end blocks use CLI flags for setup and teardown:
+```bash
+echo -e "5\n4\n3\n2\n1" | snail --awk -b 'total = 0' -e 'print("Sum:", total)' '/^[0-9]+/ { total = total + int($1) }'
+```
 
 ### Compact Error Handling
 

--- a/crates/snail-core/src/lib.rs
+++ b/crates/snail-core/src/lib.rs
@@ -34,3 +34,17 @@ pub fn compile_snail_source_with_auto_print(
         }
     }
 }
+
+/// Compile an awk program with separate begin and end code blocks.
+/// Each begin/end source is parsed as a regular Snail program.
+pub fn compile_awk_source_with_begin_end(
+    py: Python<'_>,
+    main_source: &str,
+    begin_sources: &[&str],
+    end_sources: &[&str],
+    auto_print_last: bool,
+) -> Result<PyObject, SnailError> {
+    let program = parse_awk_program_with_begin_end(main_source, begin_sources, end_sources)?;
+    let module = lower_awk_program_with_auto_print(py, &program, auto_print_last)?;
+    Ok(module)
+}

--- a/crates/snail-parser/src/snail.pest
+++ b/crates/snail-parser/src/snail.pest
@@ -2,11 +2,9 @@
 program = { SOI ~ stmt_sep* ~ stmt_list? ~ stmt_sep* ~ EOI }
 awk_program = { SOI ~ stmt_sep* ~ awk_entry_list? ~ stmt_sep* ~ EOI }
 
-// AWK mode: BEGIN blocks, END blocks, and pattern-action rules
+// AWK mode: pattern-action rules
 awk_entry_list = { awk_entry ~ (stmt_sep* ~ awk_entry)* ~ stmt_sep* }
-awk_entry = _{ awk_begin | awk_end | awk_rule }
-awk_begin = { "BEGIN" ~ block }
-awk_end = { "END" ~ block }
+awk_entry = _{ awk_rule }
 awk_rule = { block | awk_pattern ~ block? }
 awk_pattern = { expr }
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -280,11 +280,21 @@ del temp_value
 
 ## Awk mode
 Invoke Snail's awk mode with `snail --awk`. Awk sources are composed of
-pattern/action pairs evaluated for each input line. `BEGIN` and `END` blocks
-run before and after the line loop, a rule with only a pattern prints matching
-lines by default, and a lone block runs for every line.
+pattern/action pairs evaluated for each input line. A rule with only a pattern
+prints matching lines by default, and a lone block runs for every line.
 
-See `examples/awk.snail` for a runnable sample program.
+Begin and end blocks are specified via CLI flags:
+- `-b <code>`: Code to run before processing lines (repeatable)
+- `-e <code>`: Code to run after processing lines (repeatable)
+
+Example:
+```bash
+echo "hello" | snail --awk -b 'print("start")' -e 'print("done")' '{ print($0) }'
+# Output: start\nhello\ndone
+```
+
+Multiple `-b` and `-e` flags are processed in order. See `examples/awk.snail`
+for a runnable sample program.
 
 While processing, Snail populates awk-style variables:
 - `$0`: the current line with the trailing newline removed.

--- a/examples/awk.snail
+++ b/examples/awk.snail
@@ -1,6 +1,4 @@
-#!/usr/bin/env -S snail --awk -f
-BEGIN { print("demo begin") }
+#!/usr/bin/env -S snail --awk -b 'print("demo begin")' -e 'print("demo end")' -f
 $0.startswith("d") { print("matched:", $0) }
 /de(mo)/ { print("regex:", $m.1) }
 { print($fn); print($0) }
-END { print("demo end") }


### PR DESCRIPTION
## Summary
- Remove `BEGIN { }` and `END { }` syntax from awk mode grammar
- Add `-b <code>` and `-e <code>` CLI flags for begin/end blocks
- Multiple flags allowed and processed in order

## Changes
- **Grammar**: Remove `awk_begin`/`awk_end` rules from `snail.pest`
- **Parser**: Add `parse_awk_program_with_begin_end()` function
- **Core API**: Add `compile_awk_source_with_begin_end()` function
- **Python Extension**: Add `begin_code`/`end_code` parameters
- **CLI**: Add `-b`/`-e` flag parsing with `--awk` mode validation
- **Examples/Docs**: Updated to use new CLI flag syntax

## Test plan
- [x] Parser tests for new function and BEGIN/END as patterns
- [x] CLI tests for `-b`, `-e`, multiple flags, interleaved order
- [x] CLI test for `-b`/`-e` without `--awk` producing error
- [x] `make test` passes

## Usage
```bash
echo "hello" | snail --awk -b 'print("start")' -e 'print("end")' '{ print($0) }'
# Output: start\nhello\nend
```

Closes #63