### PR TITLE
Add --begin/--end CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Process files line-by-line with familiar awk semantics:
 | `$p` | Current file path |
 | `$m` | Last regex match object |
 
-Begin/end blocks use CLI flags for setup and teardown:
+Begin/end blocks use CLI flags (`-b`/`--begin`, `-e`/`--end`) for setup and teardown:
 ```bash
-echo -e "5\n4\n3\n2\n1" | snail --awk -b 'total = 0' -e 'print("Sum:", total)' '/^[0-9]+/ { total = total + int($1) }'
+echo -e "5\n4\n3\n2\n1" | snail --awk --begin 'total = 0' --end 'print("Sum:", total)' '/^[0-9]+/ { total = total + int($1) }'
 ```
 
 ### Compact Error Handling

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -287,16 +287,16 @@ pattern/action pairs evaluated for each input line. A rule with only a pattern
 prints matching lines by default, and a lone block runs for every line.
 
 Begin and end blocks are specified via CLI flags:
-- `-b <code>`: Code to run before processing lines (repeatable)
-- `-e <code>`: Code to run after processing lines (repeatable)
+- `-b <code>` or `--begin <code>`: Code to run before processing lines (repeatable)
+- `-e <code>` or `--end <code>`: Code to run after processing lines (repeatable)
 
 Example:
 ```bash
-echo "hello" | snail --awk -b 'print("start")' -e 'print("done")' '{ print($0) }'
+echo "hello" | snail --awk --begin 'print("start")' --end 'print("done")' '{ print($0) }'
 # Output: start\nhello\ndone
 ```
 
-Multiple `-b` and `-e` flags are processed in order. See `examples/awk.snail`
+Multiple `-b`/`--begin` and `-e`/`--end` flags are processed in order. See `examples/awk.snail`
 for a runnable sample program.
 
 While processing, Snail populates awk-style variables:

--- a/python/snail/cli.py
+++ b/python/snail/cli.py
@@ -107,8 +107,8 @@ def _print_help(file=sys.stdout) -> None:
     print("  -f <file>               read Snail source from file", file=file)
     print("  -a, --awk               awk mode", file=file)
     print("  -m, --map               map mode (process files one at a time)", file=file)
-    print("  -b <code>               begin block code (awk mode only, repeatable)", file=file)
-    print("  -e <code>               end block code (awk mode only, repeatable)", file=file)
+    print("  -b, --begin <code>       begin block code (awk mode only, repeatable)", file=file)
+    print("  -e, --end <code>         end block code (awk mode only, repeatable)", file=file)
     print("  -P, --no-print          disable auto-print of last expression", file=file)
     print("  -I, --no-auto-import    disable auto-imports", file=file)
     print("  --debug                 parse and compile, then print, do not run", file=file)
@@ -130,7 +130,7 @@ def _parse_args(argv: list[str]) -> _Args:
                 # Already found code, rest are args
                 args.args.extend(argv[idx:])
                 return args
-            # This is the code, continue parsing for -b/-e after
+            # This is the code, continue parsing for -b/--begin and -e/--end after
             args.args = [token]
             code_found = True
             idx += 1
@@ -168,15 +168,15 @@ def _parse_args(argv: list[str]) -> _Args:
             args.file = argv[idx + 1]
             idx += 2
             continue
-        if token == "-b":
+        if token in ("-b", "--begin"):
             if idx + 1 >= len(argv):
-                raise ValueError("option -b requires an argument")
+                raise ValueError(f"option {token} requires an argument")
             args.begin_code.append(argv[idx + 1])
             idx += 2
             continue
-        if token == "-e":
+        if token in ("-e", "--end"):
             if idx + 1 >= len(argv):
-                raise ValueError("option -e requires an argument")
+                raise ValueError(f"option {token} requires an argument")
             args.end_code.append(argv[idx + 1])
             idx += 2
             continue
@@ -233,9 +233,9 @@ def main(argv: list[str] | None = None) -> int:
         print("error: --awk and --map cannot be used together", file=sys.stderr)
         return 2
 
-    # Validate -b/-e only with --awk mode
+    # Validate -b/--begin and -e/--end only with --awk mode
     if (namespace.begin_code or namespace.end_code) and not namespace.awk:
-        print("error: -b and -e options require --awk mode", file=sys.stderr)
+        print("error: -b/--begin and -e/--end options require --awk mode", file=sys.stderr)
         return 2
 
     mode = "map" if namespace.map else ("awk" if namespace.awk else "snail")

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -292,11 +292,29 @@ def test_awk_begin_flag(
     assert captured.out == "start\nline\n"
 
 
+def test_awk_begin_long_flag(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("line\n"))
+    assert main(["--awk", "--begin", "print('start')", "{ print($0) }"]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "start\nline\n"
+
+
 def test_awk_end_flag(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(sys, "stdin", io.StringIO("line\n"))
     assert main(["--awk", "-e", "print('done')", "{ print($0) }"]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "line\ndone\n"
+
+
+def test_awk_end_long_flag(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO("line\n"))
+    assert main(["--awk", "--end", "print('done')", "{ print($0) }"]) == 0
     captured = capsys.readouterr()
     assert captured.out == "line\ndone\n"
 
@@ -308,9 +326,9 @@ def test_awk_multiple_begin_end_flags(
     assert main([
         "--awk",
         "-b", "print('b1')",
-        "-b", "print('b2')",
+        "--begin", "print('b2')",
         "-e", "print('e1')",
-        "-e", "print('e2')",
+        "--end", "print('e2')",
         "{ print($0) }",
     ]) == 0
     captured = capsys.readouterr()
@@ -333,10 +351,10 @@ def test_awk_begin_end_interleaved_order(
 
 
 def test_begin_end_without_awk_mode_fails(capsys: pytest.CaptureFixture[str]) -> None:
-    result = main(["-b", "print('x')", "print('y')"])
+    result = main(["--begin", "print('x')", "print('y')"])
     assert result == 2
     captured = capsys.readouterr()
-    assert "-b and -e options require --awk mode" in captured.err
+    assert "-b/--begin and -e/--end options require --awk mode" in captured.err
 
 
 # --- Tests for auto-import ---


### PR DESCRIPTION
## Summary
- add --begin/--end long flags for awk begin/end blocks
- update CLI help, tests, and docs to mention long flags

## Testing
- make test