### PR TITLE
Add begin/end blocks support for map mode

### DIFF
--- a/crates/snail-core/src/lib.rs
+++ b/crates/snail-core/src/lib.rs
@@ -53,3 +53,37 @@ pub fn compile_awk_source_with_begin_end(
     let module = lower_awk_program_with_auto_print(py, &program, auto_print_last)?;
     Ok(module)
 }
+
+/// Compile a map program with separate begin and end code blocks.
+/// Each begin/end source is parsed as a map program.
+pub fn compile_map_source_with_begin_end(
+    py: Python<'_>,
+    main_source: &str,
+    begin_sources: &[&str],
+    end_sources: &[&str],
+    auto_print_last: bool,
+) -> Result<PyObject, SnailError> {
+    let program = parse_map_program(main_source)?;
+    let mut begin_blocks = Vec::new();
+    for source in begin_sources {
+        let begin_program = parse_map_program(source)?;
+        if !begin_program.stmts.is_empty() {
+            begin_blocks.push(begin_program.stmts);
+        }
+    }
+    let mut end_blocks = Vec::new();
+    for source in end_sources {
+        let end_program = parse_map_program(source)?;
+        if !end_program.stmts.is_empty() {
+            end_blocks.push(end_program.stmts);
+        }
+    }
+    let module = lower_map_program_with_begin_end(
+        py,
+        &program,
+        &begin_blocks,
+        &end_blocks,
+        auto_print_last,
+    )?;
+    Ok(module)
+}

--- a/crates/snail-lower/src/lib.rs
+++ b/crates/snail-lower/src/lib.rs
@@ -11,7 +11,9 @@ mod stmt;
 
 // Re-export public API
 pub use constants::*;
-pub use map::{lower_map_program, lower_map_program_with_auto_print};
+pub use map::{
+    lower_map_program, lower_map_program_with_auto_print, lower_map_program_with_begin_end,
+};
 pub use program::{
     lower_awk_program, lower_awk_program_with_auto_print, lower_program,
     lower_program_with_auto_print,

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -8,6 +8,23 @@ blocks for curly braces. The examples here mirror the runnable tour in
 - Run a one-liner: `snail "print('hi')"`
 - Execute a file: `snail -f path/to/script.snail`
 
+## Map mode
+Map mode processes input files one at a time:
+```bash
+snail --map "print($src)" file_a.txt file_b.txt
+```
+
+Map mode provides three special variables:
+- `$src`: current file path
+- `$fd`: open file handle for the current file
+- `$text`: lazy text view of the current file contents
+
+You can also run setup/teardown blocks with `--begin` and `--end`, which execute
+once before the first file and once after the last file:
+```bash
+snail --map --begin "print('start')" --end "print('done')" "print($src)" *.txt
+```
+
 ## Modules and imports
 Snail uses Python's import semantics and exposes the same namespaces:
 ```snail

--- a/python/snail/cli.py
+++ b/python/snail/cli.py
@@ -111,8 +111,14 @@ def _print_help(file=None) -> None:
     print("  -f <file>               read Snail source from file", file=file)
     print("  -a, --awk               awk mode", file=file)
     print("  -m, --map               map mode (process files one at a time)", file=file)
-    print("  -b, --begin <code>       begin block code (awk mode only, repeatable)", file=file)
-    print("  -e, --end <code>         end block code (awk mode only, repeatable)", file=file)
+    print(
+        "  -b, --begin <code>       begin block code (awk/map mode, repeatable)",
+        file=file,
+    )
+    print(
+        "  -e, --end <code>         end block code (awk/map mode, repeatable)",
+        file=file,
+    )
     print("  -P, --no-print          disable auto-print of last expression", file=file)
     print("  -I, --no-auto-import    disable auto-imports", file=file)
     print("  --debug                 parse and compile, then print, do not run", file=file)
@@ -286,9 +292,12 @@ def main(argv: list[str] | None = None) -> int:
         print("error: --awk and --map cannot be used together", file=sys.stderr)
         return 2
 
-    # Validate -b/--begin and -e/--end only with --awk mode
-    if (namespace.begin_code or namespace.end_code) and not namespace.awk:
-        print("error: -b/--begin and -e/--end options require --awk mode", file=sys.stderr)
+    # Validate -b/--begin and -e/--end only with --awk or --map mode
+    if (namespace.begin_code or namespace.end_code) and not (namespace.awk or namespace.map):
+        print(
+            "error: -b/--begin and -e/--end options require --awk or --map mode",
+            file=sys.stderr,
+        )
         return 2
 
     mode = "map" if namespace.map else ("awk" if namespace.awk else "snail")


### PR DESCRIPTION
### Motivation
- Enable `--begin`/`--end` setup/teardown blocks for map mode so users can run one-time initialization and cleanup when processing files one-at-a-time.
- Ensure map-mode special variables (`$src`, `$fd`, `$text`) are available to begin blocks and documented for users.

### Description
- Added `lower_map_program_with_begin_end` in `crates/snail-lower/src/map.rs` and initialize `__snail` map variables (`__snail_src`, `__snail_fd`, `__snail_text`) before running begin blocks.
- Exported the new lowering entry and implemented `compile_map_source_with_begin_end` in `crates/snail-core/src/lib.rs` to parse begin/end sources and pass them to lowering.
- Updated the native Python wrapper `crates/snail-python/src/lib.rs` to dispatch begin/end compilation for both `awk` and `map` modes.
- Updated CLI help/validation in `python/snail/cli.py` to allow `-b/--begin` and `-e/--end` with `--map`, added tests in `python/tests/test_cli.py` for map begin/end behavior, and documented the feature in `docs/REFERENCE.md`.

### Testing
- Ran the repository verification flow with `make test` which runs formatting, Rust build/tests, clippy, and Python tests, and confirmed it completed successfully.
- Ran `cargo test` and Rust unit tests passed with zero failures.
- Ran Python CLI tests with `uv run -- python -m pytest python/tests` and all tests passed (`74 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973231689408325a126705c4aeefa35)