### PR TITLE
Reject compact try on binding expressions

### DIFF
--- a/crates/snail-parser/src/expr.rs
+++ b/crates/snail-parser/src/expr.rs
@@ -538,6 +538,16 @@ fn parse_primary(pair: Pair<'_, Rule>, source: &str) -> Result<Expr, ParseError>
                 };
             }
             Rule::try_suffix => {
+                if matches!(
+                    expr,
+                    Expr::AugAssign { .. } | Expr::PrefixIncr { .. } | Expr::PostfixIncr { .. }
+                ) {
+                    return Err(error_with_span(
+                        "compact try cannot wrap a binding expression",
+                        expr_span(&expr).clone(),
+                        source,
+                    ));
+                }
                 let mut suffix_inner = suffix.into_inner();
                 let fallback = suffix_inner
                     .next()

--- a/crates/snail-parser/tests/parser.rs
+++ b/crates/snail-parser/tests/parser.rs
@@ -616,6 +616,19 @@ fn parser_rejects_prefix_incr_on_try_expr() {
 }
 
 #[test]
+fn parser_rejects_compact_try_on_binding_expressions() {
+    parse_err("x++?");
+    parse_err("y:0? *= 3");
+    parse_err("x? += 1");
+
+    let program = parse_ok("(x++)?");
+    assert_eq!(program.stmts.len(), 1);
+
+    let program = parse_ok("x += y:0?");
+    assert_eq!(program.stmts.len(), 1);
+}
+
+#[test]
 fn parses_list_and_dict_literals_and_comprehensions() {
     let source = "nums = [1, 2, 3]\npairs = {\"a\": 1, \"b\": 2}\nevens = [n for n in nums if n % 2 == 0]\nlookup = {n: n * 2 for n in nums if n > 1}\n";
     let program = parse_ok(source);


### PR DESCRIPTION
### Motivation
- Prevent the compact-try suffix (`?`) from being applied to binding expressions (augmented assignment and prefix/postfix increments) which are not valid targets for compact try semantics.

### Description
- Add a guard in `parse_primary` inside the `Rule::try_suffix` branch to return a parse error when the inner expression is `Expr::AugAssign`, `Expr::PrefixIncr`, or `Expr::PostfixIncr`.
- Add parser tests in `crates/snail-parser/tests/parser.rs` (`parser_rejects_compact_try_on_binding_expressions`) that assert error cases like `x++?`, `y:0? *= 3`, and `x? += 1` and valid acceptance of `(x++)?` and `x += y:0?` where parentheses or other locations make parsing legal.

### Testing
- Ran the repository test workflow via `make test`, which runs formatting checks, `RUSTFLAGS="-D warnings" cargo build`, `cargo clippy -- -D warnings`, `cargo test` (including proptest build), and `uv run -- python -m pytest python/tests`, and all checks passed.
- Rust unit and parser test suites passed and the Python CLI tests completed with `81 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697715683884832595d4ebdce1f7368f)