### PR TITLE
Unify subprocess interpolation with f-string parsing

### DIFF
--- a/crates/snail-ast/src/ast.rs
+++ b/crates/snail-ast/src/ast.rs
@@ -399,7 +399,7 @@ pub enum SubprocessKind {
 #[derive(Debug, Clone, PartialEq)]
 pub enum SubprocessPart {
     Text(String),
-    Expr(Box<Expr>),
+    Expr(FStringExpr),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/snail-parser/src/lib.rs
+++ b/crates/snail-parser/src/lib.rs
@@ -627,7 +627,7 @@ fn validate_expr_for_map(expr: &Expr, source: &str) -> Result<(), ParseError> {
         Expr::Subprocess { parts, .. } => {
             for part in parts {
                 if let SubprocessPart::Expr(expr) = part {
-                    validate_expr_for_map(expr, source)?;
+                    validate_fstring_expr_for_map(expr, source)?;
                 }
             }
         }
@@ -709,11 +709,16 @@ fn validate_regex_pattern_for_map(pattern: &RegexPattern, source: &str) -> Resul
 
 fn validate_fstring_part_for_map(part: &FStringPart, source: &str) -> Result<(), ParseError> {
     if let FStringPart::Expr(expr) = part {
-        validate_expr_for_map(&expr.expr, source)?;
-        if let Some(spec) = &expr.format_spec {
-            for spec_part in spec {
-                validate_fstring_part_for_map(spec_part, source)?;
-            }
+        validate_fstring_expr_for_map(expr, source)?;
+    }
+    Ok(())
+}
+
+fn validate_fstring_expr_for_map(expr: &FStringExpr, source: &str) -> Result<(), ParseError> {
+    validate_expr_for_map(&expr.expr, source)?;
+    if let Some(spec) = &expr.format_spec {
+        for spec_part in spec {
+            validate_fstring_part_for_map(spec_part, source)?;
         }
     }
     Ok(())
@@ -1013,7 +1018,7 @@ fn validate_expr(expr: &Expr, source: &str) -> Result<(), ParseError> {
         Expr::Subprocess { parts, .. } => {
             for part in parts {
                 if let SubprocessPart::Expr(expr) = part {
-                    validate_expr(expr, source)?;
+                    validate_fstring_expr(expr, source)?;
                 }
             }
         }
@@ -1095,11 +1100,16 @@ fn validate_regex_pattern(pattern: &RegexPattern, source: &str) -> Result<(), Pa
 
 fn validate_fstring_part(part: &FStringPart, source: &str) -> Result<(), ParseError> {
     if let FStringPart::Expr(expr) = part {
-        validate_expr(&expr.expr, source)?;
-        if let Some(spec) = &expr.format_spec {
-            for spec_part in spec {
-                validate_fstring_part(spec_part, source)?;
-            }
+        validate_fstring_expr(expr, source)?;
+    }
+    Ok(())
+}
+
+fn validate_fstring_expr(expr: &FStringExpr, source: &str) -> Result<(), ParseError> {
+    validate_expr(&expr.expr, source)?;
+    if let Some(spec) = &expr.format_spec {
+        for spec_part in spec {
+            validate_fstring_part(spec_part, source)?;
         }
     }
     Ok(())

--- a/crates/snail-parser/src/literal.rs
+++ b/crates/snail-parser/src/literal.rs
@@ -239,131 +239,20 @@ pub fn parse_subprocess_body(
     source: &str,
     span: SourceSpan,
 ) -> Result<Vec<SubprocessPart>, ParseError> {
-    let mut parts = Vec::new();
-    for inner in pair.into_inner() {
-        match inner.as_rule() {
-            Rule::subprocess_text => {
-                let start_offset = inner.as_span().start();
-                let text_parts = parse_subprocess_text_parts(inner.as_str(), start_offset, source)?;
-                parts.extend(text_parts);
-            }
-            Rule::subprocess_expr => {
-                let expr_pair = inner.into_inner().next().ok_or_else(|| {
-                    error_with_span("missing subprocess expression", span.clone(), source)
-                })?;
-                let expr = crate::expr::parse_expr_pair(expr_pair, source)?;
-                parts.push(SubprocessPart::Expr(Box::new(expr)));
-            }
-            _ => {}
-        }
-    }
+    let content = pair.as_str();
+    let content_offset = pair.as_span().start();
+    let fstring_parts = parse_fstring_parts(content, content_offset, source)?;
+    let parts = fstring_parts
+        .into_iter()
+        .map(|part| match part {
+            FStringPart::Text(text) => SubprocessPart::Text(text),
+            FStringPart::Expr(expr) => SubprocessPart::Expr(expr),
+        })
+        .collect::<Vec<_>>();
     if parts.is_empty() {
         return Err(error_with_span("missing subprocess command", span, source));
     }
     Ok(parts)
-}
-
-pub fn parse_subprocess_text_parts(
-    text: &str,
-    start_offset: usize,
-    source: &str,
-) -> Result<Vec<SubprocessPart>, ParseError> {
-    let mut parts = Vec::new();
-    let mut buffer = String::new();
-    let mut iter = text.char_indices().peekable();
-
-    while let Some((idx, ch)) = iter.next() {
-        match ch {
-            '{' => {
-                if matches!(iter.peek(), Some((_, '{'))) {
-                    iter.next();
-                }
-                buffer.push('{');
-            }
-            '}' => {
-                if matches!(iter.peek(), Some((_, '}'))) {
-                    iter.next();
-                }
-                buffer.push('}');
-            }
-            '$' => {
-                if matches!(iter.peek(), Some((_, '$'))) {
-                    iter.next();
-                    buffer.push('$');
-                    continue;
-                }
-
-                if let Some((_, next_ch)) = iter.peek().copied()
-                    && next_ch.is_ascii_digit()
-                {
-                    let mut digits = String::new();
-                    let mut end = idx + 1;
-                    while let Some((d_idx, d_ch)) = iter.peek().copied() {
-                        if d_ch.is_ascii_digit() {
-                            iter.next();
-                            digits.push(d_ch);
-                            end = d_idx + d_ch.len_utf8();
-                        } else {
-                            break;
-                        }
-                    }
-                    if !buffer.is_empty() {
-                        parts.push(SubprocessPart::Text(std::mem::take(&mut buffer)));
-                    }
-                    let span = crate::util::span_from_offset(
-                        start_offset + idx,
-                        start_offset + end,
-                        source,
-                    );
-                    parts.push(SubprocessPart::Expr(Box::new(Expr::FieldIndex {
-                        index: digits,
-                        span,
-                    })));
-                    continue;
-                }
-
-                if let Some((name, len)) = match_injected_name(&text[idx + 1..]) {
-                    for _ in 0..len {
-                        iter.next();
-                    }
-                    if !buffer.is_empty() {
-                        parts.push(SubprocessPart::Text(std::mem::take(&mut buffer)));
-                    }
-                    let span = crate::util::span_from_offset(
-                        start_offset + idx,
-                        start_offset + idx + 1 + len,
-                        source,
-                    );
-                    parts.push(SubprocessPart::Expr(Box::new(Expr::Name {
-                        name: format!("${name}"),
-                        span,
-                    })));
-                    continue;
-                }
-
-                buffer.push('$');
-            }
-            _ => buffer.push(ch),
-        }
-    }
-
-    if !buffer.is_empty() {
-        parts.push(SubprocessPart::Text(buffer));
-    }
-
-    Ok(parts)
-}
-
-pub fn match_injected_name(text: &str) -> Option<(&'static str, usize)> {
-    if text.starts_with("fn") {
-        return Some(("fn", 2));
-    }
-    for name in ["l", "f", "n", "p", "m", "e"] {
-        if text.starts_with(name) {
-            return Some((name, 1));
-        }
-    }
-    None
 }
 
 pub fn parse_structured_accessor(pair: Pair<'_, Rule>, source: &str) -> Result<Expr, ParseError> {

--- a/crates/snail-parser/src/snail.pest
+++ b/crates/snail-parser/src/snail.pest
@@ -227,10 +227,7 @@ compound_expr = { "(" ~ NEWLINE* ~ expr ~ (";" ~ NEWLINE* ~ expr)+ ~ NEWLINE* ~ 
 subprocess = { subprocess_capture | subprocess_status }
 subprocess_capture = { "$(" ~ subprocess_body ~ ")" }
 subprocess_status = { "@(" ~ subprocess_body ~ ")" }
-subprocess_body = { subprocess_part* }
-subprocess_part = _{ subprocess_expr | subprocess_text }
-subprocess_expr = { "{" ~ expr ~ "}" }
-subprocess_text = @{ ( "{{" | "}}" | (!("{" | ")") ~ ANY) )+ }
+subprocess_body = @{ (!")" ~ ANY)* }
 
 // Structured pipeline accessor: $[query] for querying structured data
 // The query is treated as a raw string (no interpolation)

--- a/crates/snail-python/src/lower/desugar.rs
+++ b/crates/snail-python/src/lower/desugar.rs
@@ -594,7 +594,7 @@ impl LambdaHoister {
                     .map(|part| match part {
                         SubprocessPart::Text(text) => SubprocessPart::Text(text.clone()),
                         SubprocessPart::Expr(expr) => {
-                            SubprocessPart::Expr(Box::new(self.desugar_expr(expr, prelude)))
+                            SubprocessPart::Expr(self.desugar_fstring_expr(expr, prelude))
                         }
                     })
                     .collect(),

--- a/crates/snail-python/src/lower/validate.rs
+++ b/crates/snail-python/src/lower/validate.rs
@@ -285,7 +285,7 @@ fn check_expr(expr: &Expr, in_function: bool) -> Result<(), LowerError> {
         Expr::Subprocess { parts, .. } => {
             for part in parts {
                 if let SubprocessPart::Expr(expr) = part {
-                    check_expr(expr, in_function)?;
+                    check_fstring_expr(expr, in_function)?;
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- Replace the bespoke subprocess interpolation parser with the shared f-string parser so subprocess commands support the same conversions and format-specs as regular f-strings.
- Preserve and propagate f-string conversion flags and format-specs through the AST and lowering so subprocess interpolation behaves consistently end-to-end.

### Description
- Changed the AST `SubprocessPart::Expr` to carry `FStringExpr` instead of `Box<Expr>` so conversions/format-specs are preserved in subprocess parts (`crates/snail-ast/src/ast.rs`).
- Parser now parses subprocess bodies using the central f-string parser (`parse_fstring_parts`) and maps `FStringPart` into `SubprocessPart`, and the bespoke subprocess text parser and injected-name handling were removed (`crates/snail-parser/src/literal.rs`, `crates/snail-parser/src/snail.pest`).
- Validation helpers were added/updated to validate f-string expressions in subprocess contexts (`validate_fstring_expr*` / `validate_fstring_part*` in `crates/snail-parser/src/lib.rs`).
- Desugaring and lowering were adjusted to treat subprocess parts as f-strings: desugar uses `desugar_fstring_expr`, lowering reuses `lower_fstring_parts`, and placeholder/count/ substitute helpers were updated to operate on `FStringExpr` (`crates/snail-python/src/lower/desugar.rs`, `crates/snail-python/src/lower/expr.rs`, `crates/snail-python/src/lower/validate.rs`).
- Added a parser test that checks subprocess f-string conversion and format-spec propagation (`crates/snail-parser/tests/syntax_expressions.rs`).

### Testing
- Ran the full project test workflow via `make test`, which runs formatting checks, clippy, Rust unit tests, builds the Python extension and runs `python -m pytest python/tests`; all checks completed successfully.
- All Rust unit tests and Python CLI tests passed (`cargo test` and `python -m pytest`), including the new subprocess f-string formatting test (total tests passed as shown by `make test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69840010c4fc83259867734ded603f30)