### PR TITLE
feat: make @() return SnailExitStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ greeting = $(echo hello {name})
 result = "foo\nbar\nbaz" | $(grep bar) | $(cat -n)
 
 # Check command status
-@(make build)?  # returns exit code on failure instead of raising
+status = @(make build)?  # returns SnailExitStatus on failure instead of raising
+if status { print("build passed") } else { print(status.rc) }
 ```
 
 

--- a/examples/all_syntax.snail
+++ b/examples/all_syntax.snail
@@ -173,7 +173,7 @@ brace_text = "brace {{ok}}"
 # ---- Subprocess and pipeline syntax ----
 cmd_name = "snail"
 # $(...) captures stdout
-# @(...) returns status (raise on non-zero, with ? to swallow)
+# @(...) returns SnailExitStatus (raise on non-zero, with ? to swallow)
 echoed = $(echo {cmd_name})
 try {
     echoed = $(__snail_missing_command__)? # it is required to provide a default value for this form.
@@ -183,6 +183,11 @@ try {
 assert echoed == "default"
 status_ok = @(echo ready)
 status_fail = @(__snail_missing_command__)?
+assert status_ok
+assert status_ok.rc == 0
+assert not status_fail
+assert status_fail.rc != 0
+assert status_fail == status_fail.rc
 
 # Subprocess pipelines and placeholder arguments
 piped = "test" | $(more)

--- a/python/snail/runtime/subprocess.py
+++ b/python/snail/runtime/subprocess.py
@@ -4,6 +4,20 @@ import subprocess
 from typing import Any, cast
 
 
+class SnailExitStatus(int):
+    """Subprocess exit status with shell-like truthiness."""
+
+    def __new__(cls, rc: int) -> "SnailExitStatus":
+        return cast("SnailExitStatus", super().__new__(cls, rc))
+
+    def __bool__(self) -> bool:
+        return int(self) == 0
+
+    @property
+    def rc(self) -> int:
+        return int(self)
+
+
 def _run_subprocess(cmd: str, input_data=None, *, capture: bool):
     if isinstance(input_data, bytes):
         input_data = input_data.decode()
@@ -50,11 +64,11 @@ class SubprocessStatus:
     def __call__(self, input_data=None):
         try:
             _run_subprocess(self.cmd, input_data, capture=False)
-            return 0
+            return SnailExitStatus(0)
         except subprocess.CalledProcessError as exc:
 
             def __fallback(exc=exc):
-                return exc.returncode
+                return SnailExitStatus(exc.returncode)
 
             exc.__fallback__ = __fallback
             raise


### PR DESCRIPTION
## Summary
- change `@(...)` to return `SnailExitStatus` instead of raw integer `0`
- implement shell-style truthiness for `SnailExitStatus` (`0` is truthy, non-zero is falsy)
- expose numeric return code via `SnailExitStatus.rc`
- keep `$(...)` behavior unchanged
- update docs and examples to reflect new subprocess status semantics

## Testing
- `uv run -- python -m pytest python/tests/test_cli.py -k "subprocess_status or test_test_subprocess"`
- `uv run -- python -m pytest python/tests/test_cli.py -k "example_all_syntax or readme_snail_blocks_parse or readme_snail_oneliners"`
- `make test`
